### PR TITLE
Make the prefix of generated functions customisable through KSP arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,15 @@ fun createFoo(
 ```
 
 The naming convention for the generated function is the class' name with the
-`create` prefix. So, from the `Foo` class, the `createFoo` function will be generated.
+`create` prefix. So, from the `Foo` class, the `createFoo()` function will be generated.
 This function will be placed in a file with the `FooFixture.kt` name, and the file 
 will be placed in the `Foo`'s package under the `build/generated/ksp/kotlin/` path.
+
+You can change the default `create` prefix to some other value, for example to generate `foo()` function instead:
+
+```gradle
+ksp.arg("fixtures.prefix", "")
+```
 
 ## Randomize your data
 The generated functions have default values for their parameters. The values are [standard](#Supported-field-types) 

--- a/fixtures-processor/src/main/kotlin/com/theblueground/fixtures/FixtureBuilderGenerator.kt
+++ b/fixtures-processor/src/main/kotlin/com/theblueground/fixtures/FixtureBuilderGenerator.kt
@@ -28,7 +28,7 @@ internal class FixtureBuilderGenerator(
     private val valueGenerator = ParameterValueGenerator()
 
     fun generate(
-        randomize: Boolean,
+        kspArguments: KspArguments,
         containingFile: KSFile,
         processedFixtures: List<ProcessedFixture>,
         fixtureAdapters: Map<TypeName, ProcessedFixtureAdapter>,
@@ -40,7 +40,7 @@ internal class FixtureBuilderGenerator(
         processedFixtures.forEach {
             fileSpec.addFunction(
                 funSpec = it.toFunSpec(
-                    randomize = randomize,
+                    kspArguments = kspArguments,
                     containingFile = containingFile,
                     fixtureAdapters = fixtureAdapters,
                 ),
@@ -53,11 +53,12 @@ internal class FixtureBuilderGenerator(
     }
 
     private fun ProcessedFixture.toFunSpec(
-        randomize: Boolean,
+        kspArguments: KspArguments,
         containingFile: KSFile,
         fixtureAdapters: Map<TypeName, ProcessedFixtureAdapter>,
     ): FunSpec {
-        val functionName = "create$parentName${simpleName.replaceFirstChar { it.uppercaseChar() }}"
+        val functionName = "${kspArguments.prefix}$parentName${simpleName.replaceFirstChar { it.uppercaseChar() }}"
+            .replaceFirstChar { it.lowercaseChar() }
 
         val funSpec = FunSpec.builder(name = functionName)
             .addOriginatingKSFile(containingFile)
@@ -65,7 +66,7 @@ internal class FixtureBuilderGenerator(
         parameters.forEach {
             funSpec.addParameter(
                 parameterSpec = it.toParameterSpec(
-                    randomize = randomize,
+                    kspArguments = kspArguments,
                     fixtureAdapters = fixtureAdapters,
                 ),
             )
@@ -76,11 +77,11 @@ internal class FixtureBuilderGenerator(
     }
 
     private fun ProcessedFixtureParameter.toParameterSpec(
-        randomize: Boolean,
+        kspArguments: KspArguments,
         fixtureAdapters: Map<TypeName, ProcessedFixtureAdapter>,
     ): ParameterSpec {
         val defaultValue = valueGenerator.generateDefaultValue(
-            randomize = randomize,
+            kspArguments = kspArguments,
             parameter = this,
             fixtureAdapters = fixtureAdapters,
         )

--- a/fixtures-processor/src/main/kotlin/com/theblueground/fixtures/FixtureProcessor.kt
+++ b/fixtures-processor/src/main/kotlin/com/theblueground/fixtures/FixtureProcessor.kt
@@ -48,7 +48,10 @@ internal class FixtureProcessor(
         processedFixtures = processedFixtures,
     )
 
-    private val randomize = options["fixtures.randomize"]?.let { it.equals("true", true) } ?: false
+    private val kspArguments = KspArguments(
+        randomize = options["fixtures.randomize"]?.let { it.equals("true", true) } ?: false,
+        prefix = options["fixtures.prefix"] ?: "create",
+    )
 
     private val runFixtures = options["fixtures.run"]?.let { it.equals("true", true) } ?: true
 
@@ -105,7 +108,7 @@ internal class FixtureProcessor(
 
         processedFixtures.forEach { (containingFile, processedFixtures) ->
             fixtureBuilderGenerator.generate(
-                randomize = randomize,
+                kspArguments = kspArguments,
                 containingFile = containingFile,
                 processedFixtures = processedFixtures,
                 fixtureAdapters = processedFixtureAdapters,

--- a/fixtures-processor/src/main/kotlin/com/theblueground/fixtures/KspArguments.kt
+++ b/fixtures-processor/src/main/kotlin/com/theblueground/fixtures/KspArguments.kt
@@ -1,0 +1,6 @@
+package com.theblueground.fixtures
+
+data class KspArguments(
+    val randomize: Boolean,
+    val prefix: String,
+)

--- a/fixtures-processor/src/test/kotlin/com/theblueground/fixtures/FixtureProcessorTest.kt
+++ b/fixtures-processor/src/test/kotlin/com/theblueground/fixtures/FixtureProcessorTest.kt
@@ -37,21 +37,29 @@ class FixtureProcessorTest : KSPTest() {
                         val bigIntegerValue: BigInteger,
                         val testEnumValue: TestEnum,
                         val collectionValue: Map<Int, String>,
-                        val testSealedValue: TestSealed
+                        val testSealedObjectValue: TestSealedObject,
+                        val testSealedDataClassValue: TestSealedDataClass,
                     )
 
                     enum class TestEnum {
                         FIRST_ENUM, SECOND_ENUM
                     }
 
-                    sealed class TestSealed {
+                    sealed class TestSealedObject {
 
-                        object First : TestSealed()
+                        data class First(val name: String) : TestSealedObject()
 
-                        object Second : TestSealed()
+                        object Second : TestSealedObject()
+
+                        object Third : TestSealedObject()
+                    }
+
+                    sealed class TestSealedDataClass {
+
+                        data class First(val name: String) : TestSealedDataClass()
 
                         @Fixture
-                        data class Third(val name: String) : TestSealed()
+                        data class Second(val name: String) : TestSealedDataClass()
                     }
 
                     @Fixture
@@ -110,7 +118,8 @@ class FixtureProcessorTest : KSPTest() {
               bigIntegerValue: BigInteger = BigInteger.ZERO,
               testEnumValue: TestEnum = TestEnum.FIRST_ENUM,
               collectionValue: Map<Int, String> = emptyMap(),
-              testSealedValue: TestSealed = TestSealed.First,
+              testSealedObjectValue: TestSealedObject = TestSealedObject.Second,
+              testSealedDataClassValue: TestSealedDataClass = createTestSealedDataClassSecond(),
             ): TestClass = $packageName.$fixtureName(
             	stringValue = stringValue,
             	doubleValue = doubleValue,
@@ -125,11 +134,12 @@ class FixtureProcessorTest : KSPTest() {
             	bigIntegerValue = bigIntegerValue,
             	testEnumValue = testEnumValue,
             	collectionValue = collectionValue,
-            	testSealedValue = testSealedValue
+            	testSealedObjectValue = testSealedObjectValue,
+            	testSealedDataClassValue = testSealedDataClassValue
             )
 
-            public fun createTestSealedThird(name: String = "name"): TestSealed.Third =
-                $packageName.TestSealed.Third(
+            public fun createTestSealedDataClassSecond(name: String = "name"): TestSealedDataClass.Second =
+                $packageName.TestSealedDataClass.Second(
             	name = name
             )
 
@@ -194,7 +204,8 @@ class FixtureProcessorTest : KSPTest() {
               bigIntegerValue: BigInteger = BigInteger.ZERO,
               testEnumValue: TestEnum = TestEnum.FIRST_ENUM,
               collectionValue: Map<Int, String> = emptyMap(),
-              testSealedValue: TestSealed = TestSealed.First,
+              testSealedObjectValue: TestSealedObject = TestSealedObject.Second,
+              testSealedDataClassValue: TestSealedDataClass = createTestSealedDataClassSecond(),
             ): TestClass = $packageName.$fixtureName(
             	stringValue = stringValue,
             	doubleValue = doubleValue,
@@ -209,15 +220,194 @@ class FixtureProcessorTest : KSPTest() {
             	bigIntegerValue = bigIntegerValue,
             	testEnumValue = testEnumValue,
             	collectionValue = collectionValue,
-            	testSealedValue = testSealedValue
+            	testSealedObjectValue = testSealedObjectValue,
+            	testSealedDataClassValue = testSealedDataClassValue
             )
 
-            public fun createTestSealedThird(name: String = "name"): TestSealed.Third =
-                $packageName.TestSealed.Third(
+            public fun createTestSealedDataClassSecond(name: String = "name"): TestSealedDataClass.Second =
+                $packageName.TestSealedDataClass.Second(
             	name = name
             )
 
             public fun createTestSubClass(
+              stringValue: String = "stringValue",
+              doubleValue: Double = 0.0,
+              floatValue: Float = 0f,
+              booleanValue: Boolean = false,
+              intValue: Int = 0,
+            ): TestSubClass = $packageName.TestSubClass(
+            	stringValue = stringValue,
+            	doubleValue = doubleValue,
+            	floatValue = floatValue,
+            	booleanValue = booleanValue,
+            	intValue = intValue
+            )
+
+        """.trimIndent()
+        assertThat(generatedContent).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should generate a builder function with custom prefix when defined`() {
+        // Given
+        val fixtureFile = kotlin(name = "$fixtureName.kt", contents = fixtureSource)
+
+        // When
+        val result = compile(
+            arguments = mapOf("fixtures.prefix" to "new"),
+            sourceFiles = listOf(fixtureFile),
+        )
+        val generatedContent = getGeneratedContent(
+            packageName = packageName,
+            filename = "${fixtureName}Fixture.kt",
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        val expected = """
+            package $packageName
+
+            import java.math.BigDecimal
+            import java.math.BigInteger
+            import java.util.Date
+            import java.util.UUID
+            import kotlin.Boolean
+            import kotlin.Double
+            import kotlin.Float
+            import kotlin.Int
+            import kotlin.Long
+            import kotlin.String
+            import kotlin.collections.Map
+
+            public fun new$fixtureName(
+              stringValue: String = "stringValue",
+              doubleValue: Double = 0.0,
+              floatValue: Float = 0f,
+              booleanValue: Boolean = false,
+              intValue: Int = 0,
+              longValue: Long = 0L,
+              nestedTestValue: TestSubClass = $packageName.newTestSubClass(),
+              dateValue: Date = Date(0),
+              uuidValue: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000"),
+              bigDecimalValue: BigDecimal = BigDecimal.ZERO,
+              bigIntegerValue: BigInteger = BigInteger.ZERO,
+              testEnumValue: TestEnum = TestEnum.FIRST_ENUM,
+              collectionValue: Map<Int, String> = emptyMap(),
+              testSealedObjectValue: TestSealedObject = TestSealedObject.Second,
+              testSealedDataClassValue: TestSealedDataClass = newTestSealedDataClassSecond(),
+            ): TestClass = $packageName.$fixtureName(
+            	stringValue = stringValue,
+            	doubleValue = doubleValue,
+            	floatValue = floatValue,
+            	booleanValue = booleanValue,
+            	intValue = intValue,
+            	longValue = longValue,
+            	nestedTestValue = nestedTestValue,
+            	dateValue = dateValue,
+            	uuidValue = uuidValue,
+            	bigDecimalValue = bigDecimalValue,
+            	bigIntegerValue = bigIntegerValue,
+            	testEnumValue = testEnumValue,
+            	collectionValue = collectionValue,
+            	testSealedObjectValue = testSealedObjectValue,
+            	testSealedDataClassValue = testSealedDataClassValue
+            )
+
+            public fun newTestSealedDataClassSecond(name: String = "name"): TestSealedDataClass.Second =
+                $packageName.TestSealedDataClass.Second(
+            	name = name
+            )
+
+            public fun newTestSubClass(
+              stringValue: String = "stringValue",
+              doubleValue: Double = 0.0,
+              floatValue: Float = 0f,
+              booleanValue: Boolean = false,
+              intValue: Int = 0,
+            ): TestSubClass = $packageName.TestSubClass(
+            	stringValue = stringValue,
+            	doubleValue = doubleValue,
+            	floatValue = floatValue,
+            	booleanValue = booleanValue,
+            	intValue = intValue
+            )
+
+        """.trimIndent()
+        assertThat(generatedContent).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should generate a builder function with no prefix when defined`() {
+        // Given
+        val fixtureFile = kotlin(name = "$fixtureName.kt", contents = fixtureSource)
+
+        // When
+        val result = compile(
+            arguments = mapOf("fixtures.prefix" to ""),
+            sourceFiles = listOf(fixtureFile),
+        )
+        val generatedContent = getGeneratedContent(
+            packageName = packageName,
+            filename = "${fixtureName}Fixture.kt",
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        val expected = """
+            package $packageName
+
+            import java.math.BigDecimal
+            import java.math.BigInteger
+            import java.util.Date
+            import java.util.UUID
+            import kotlin.Boolean
+            import kotlin.Double
+            import kotlin.Float
+            import kotlin.Int
+            import kotlin.Long
+            import kotlin.String
+            import kotlin.collections.Map
+
+            public fun ${fixtureName.replaceFirstChar { it.lowercase() }}(
+              stringValue: String = "stringValue",
+              doubleValue: Double = 0.0,
+              floatValue: Float = 0f,
+              booleanValue: Boolean = false,
+              intValue: Int = 0,
+              longValue: Long = 0L,
+              nestedTestValue: TestSubClass = $packageName.testSubClass(),
+              dateValue: Date = Date(0),
+              uuidValue: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000"),
+              bigDecimalValue: BigDecimal = BigDecimal.ZERO,
+              bigIntegerValue: BigInteger = BigInteger.ZERO,
+              testEnumValue: TestEnum = TestEnum.FIRST_ENUM,
+              collectionValue: Map<Int, String> = emptyMap(),
+              testSealedObjectValue: TestSealedObject = TestSealedObject.Second,
+              testSealedDataClassValue: TestSealedDataClass = testSealedDataClassSecond(),
+            ): TestClass = $packageName.$fixtureName(
+            	stringValue = stringValue,
+            	doubleValue = doubleValue,
+            	floatValue = floatValue,
+            	booleanValue = booleanValue,
+            	intValue = intValue,
+            	longValue = longValue,
+            	nestedTestValue = nestedTestValue,
+            	dateValue = dateValue,
+            	uuidValue = uuidValue,
+            	bigDecimalValue = bigDecimalValue,
+            	bigIntegerValue = bigIntegerValue,
+            	testEnumValue = testEnumValue,
+            	collectionValue = collectionValue,
+            	testSealedObjectValue = testSealedObjectValue,
+            	testSealedDataClassValue = testSealedDataClassValue
+            )
+
+            public fun testSealedDataClassSecond(name: String = "name"): TestSealedDataClass.Second =
+                $packageName.TestSealedDataClass.Second(
+            	name = name
+            )
+
+            public fun testSubClass(
               stringValue: String = "stringValue",
               doubleValue: Double = 0.0,
               floatValue: Float = 0f,


### PR DESCRIPTION
This feature allows for easier adoption of the library when existing code base uses a different convention for naming test fixtures.

For example instead of `createFoo()` there might be `newFoo()`, `getFoo()`, or simply `foo()`.